### PR TITLE
fix dynamoDB cloudFormation

### DIFF
--- a/lessons/core-concepts/6-using-addition-resources/README.md
+++ b/lessons/core-concepts/6-using-addition-resources/README.md
@@ -77,10 +77,10 @@ Resources:
     Properties:
       TableName: 'my-table-name'
       AttributeDefinitions:
-        - AttributeName: url
+        - AttributeName: id
           AttributeType: S
       KeySchema:
-        - AttributeName: url
+        - AttributeName: id
           KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: 1


### PR DESCRIPTION
handler.js is using `id` as attribute name but the README code is using `url`